### PR TITLE
Advanced DHCP - dnsmasq.conf textarea maxlength 4K

### DIFF
--- a/trunk/user/www/n56u_ribbon_fixed/Advanced_DHCP_Content.asp
+++ b/trunk/user/www/n56u_ribbon_fixed/Advanced_DHCP_Content.asp
@@ -508,7 +508,7 @@ function changeBgColor(obj, num){
                                             <td colspan="2">
                                                 <a href="javascript:spoiler_toggle('spoiler_conf')"><span><#CustomConf#> "dnsmasq.conf"</span></a>
                                                 <div id="spoiler_conf" style="display:none;">
-                                                    <textarea rows="16" wrap="off" spellcheck="false" maxlength="4096" class="span12" name="dnsmasq.dnsmasq.conf" style="font-family:'Courier New'; font-size:12px;"><% nvram_dump("dnsmasq.dnsmasq.conf",""); %></textarea>
+                                                    <textarea rows="16" wrap="off" spellcheck="false" maxlength="16384" class="span12" name="dnsmasq.dnsmasq.conf" style="font-family:'Courier New'; font-size:12px;"><% nvram_dump("dnsmasq.dnsmasq.conf",""); %></textarea>
                                                 </div>
                                             </td>
                                         </tr>


### PR DESCRIPTION
Maxlength of dnsmasq.conf textarea increased from 4 to 16K, to match with dnsmasq.servers textarea and to allow larger config files to be edited.